### PR TITLE
fix: messages not being updated when last message is deleted

### DIFF
--- a/src/CuteChat.tsx
+++ b/src/CuteChat.tsx
@@ -1,11 +1,11 @@
-import React, { useState, useCallback, useMemo, useLayoutEffect } from 'react';
-import { GiftedChat, GiftedChatProps } from 'react-native-gifted-chat';
 import firestore, {
   FirebaseFirestoreTypes as FirebaseFirestore,
   firebase,
 } from '@react-native-firebase/firestore';
-import type { IMessage } from 'react-native-gifted-chat';
+import React, { useCallback, useLayoutEffect, useMemo, useState } from 'react';
 import { Alert } from 'react-native';
+import type { IMessage } from 'react-native-gifted-chat';
+import { GiftedChat, GiftedChatProps } from 'react-native-gifted-chat';
 
 interface CustomCuteChatProps {
   chatId: string;
@@ -157,6 +157,16 @@ export function CuteChat(props: CuteChatProps) {
       .limit(20)
       .onSnapshot(
         async (snapshot: FirebaseFirestore.QuerySnapshot) => {
+          if (snapshot.empty) {
+            setLastMessageDoc(null);
+
+            setMessages([]);
+            setIsLoading(false);
+            setInitializing(false);
+
+            markMessagesAsRead([]);
+          }
+
           if (!snapshot.empty) {
             setLastMessageDoc(
               snapshot.docs[


### PR DESCRIPTION
### Description 📖

**What?**

The package had trouble when the last message was deleted, due to any update to the `message` state being ignored if received messages were empty. This PR fixes that case when the initial messages are empty.

Before:

https://github.com/user-attachments/assets/d2ff8b6d-040e-427d-b8e5-225aa7f07d99

After:

https://github.com/user-attachments/assets/a8a4ca96-26c7-4add-aa3b-4866f02d8456

### Testing 🤞

When deleting the last message with an application using this version of the package, it should correctly be updated and be removed.

- [x] I have tested the changes on iOS
- [x] I have tested the changes on Android
